### PR TITLE
Demo 1

### DIFF
--- a/openshift-templates/coolstore-template.yaml
+++ b/openshift-templates/coolstore-template.yaml
@@ -142,25 +142,52 @@ objects:
     to:
       kind: Service
       name: web-ui
-# API Gateway
+# Coolstore Gateway
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    name: coolstore-gw
+    name: fis-java-openshift
   spec:
+    dockerImageRepository: registry.access.redhat.com/jboss-fuse-6-tech-preview/fis-java-openshift
     tags:
-    - name: latest
+    - name: "2.0"
+      annotations:
+        description: JBoss Fuse Integration Services 2.0 Java S2I images.
+        iconClass: icon-jboss
+        supports: jboss-fuse:6.3.0,java:8,xpaas:1.2
+        tags: builder,jboss-fuse,java,xpaas
+        version: "2.0"
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    creationTimestamp: null
+    labels:
+      component: coolstore-gw
+      group: quickstarts
+      project: coolstore
+      provider: s2i
+      version: 1.0
+    name: coolstore-gw
+  spec: {}
+  status:
+    dockerImageRepository: ""
 - apiVersion: v1
   kind: BuildConfig
   metadata:
     name: coolstore-gw
+    labels:
+      component: coolstore-gw
+      group: quickstarts
+      project: coolstore
+      provider: s2i
+      version: 1.0
   spec:
     output:
       to:
         kind: ImageStreamTag
         name: coolstore-gw:latest
     source:
-      contextDir: api-gateway
+      contextDir: coolstore-gw
       git:
         ref: ${GIT_REF}
         uri: ${GIT_URI}
@@ -168,12 +195,12 @@ objects:
     strategy:
       sourceStrategy:
         env:
-        - name: MAVEN_MIRROR_URL
-          value: ${MAVEN_MIRROR_URL}
+        - name: MAVEN_ARGS
+          value: package -DskipTests -Dfabric8.skip -e -B -Pearly-access-repo
+        forcePull: true
         from:
           kind: ImageStreamTag
-          name: jboss-eap70-openshift:1.4
-          namespace: openshift
+          name: fis-java-openshift:2.0
       type: Source
     triggers:
     - type: ConfigChange
@@ -183,6 +210,12 @@ objects:
   kind: DeploymentConfig
   metadata:
     name: coolstore-gw
+    labels:
+      component: coolstore-gw
+      group: quickstarts
+      project: coolstore
+      provider: s2i
+      version: 1.0
   spec:
     replicas: 1
     selector:
@@ -199,68 +232,26 @@ objects:
       spec:
         containers:
         - env:
-          - name: OPENSHIFT_KUBE_PING_LABELS
-            value: application=coolstore-gw
-          - name: OPENSHIFT_KUBE_PING_NAMESPACE
+          - name: KUBERNETES_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: MQ_CLUSTER_PASSWORD
-            value: CqUo3fYDTv
-          - name: JGROUPS_CLUSTER_PASSWORD
-            value: 9PjIzcyMGx
-          - name: AUTO_DEPLOY_EXPLODED
-            value: "false"
-          image: coolstore-gw
-          imagePullPolicy: Always
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                - /opt/eap/bin/jboss-cli.sh
-                - -c
-                - :shutdown(timeout=60)
+          image: library/coolstore-gw:latest
           livenessProbe:
-            failureThreshold: 5
             httpGet:
-              path: /
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 120
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 5
+              path: /health
+              port: 8081
+            initialDelaySeconds: 180
           name: coolstore-gw
           ports:
           - containerPort: 8778
             name: jolokia
-            protocol: TCP
-          - containerPort: 8080
-            name: http
-            protocol: TCP
-          - containerPort: 8888
-            name: ping
-            protocol: TCP
           readinessProbe:
-            failureThreshold: 10
             httpGet:
-              path: /
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 15
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 1
-          resources:
-            limits:
-              memory: 800Mi
-            requests:
-              memory: 400Mi
-          terminationMessagePath: /dev/termination-log
-        dnsPolicy: ClusterFirst
-        restartPolicy: Always
-        securityContext: {}
-        terminationGracePeriodSeconds: 75
+              path: /health
+              port: 8081
+            initialDelaySeconds: 10
+          resources: {}
     triggers:
     - imageChangeParams:
         automatic: true
@@ -295,7 +286,7 @@ objects:
   spec:
     to:
       kind: Service
-      name: coolstore-gw
+      name: coolstore-gw      
 # Inventory Service
 - apiVersion: v1
   kind: ImageStream

--- a/openshift-templates/services/coolstore-gw-template.yaml
+++ b/openshift-templates/services/coolstore-gw-template.yaml
@@ -1,0 +1,172 @@
+apiVersion: v1
+kind: Template
+labels:
+  demo: coolstore-microservice
+  template: coolstore-gw-template
+metadata:
+  annotations:
+    description: CoolStore Gateway application template
+    iconClass: icon-java
+    tags: microservice,jboss,spring
+  name: coolstore-gw-template
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: fis-java-openshift
+  spec:
+    dockerImageRepository: registry.access.redhat.com/jboss-fuse-6-tech-preview/fis-java-openshift
+    tags:
+    - name: "2.0"
+      annotations:
+        description: JBoss Fuse Integration Services 2.0 Java S2I images.
+        iconClass: icon-jboss
+        supports: jboss-fuse:6.3.0,java:8,xpaas:1.2
+        tags: builder,jboss-fuse,java,xpaas
+        version: "2.0"
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    creationTimestamp: null
+    labels:
+      component: coolstore-gw
+      group: quickstarts
+      project: coolstore
+      provider: s2i
+      version: 1.0
+    name: coolstore-gw
+  spec: {}
+  status:
+    dockerImageRepository: ""
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: coolstore-gw
+    labels:
+      component: coolstore-gw
+      group: quickstarts
+      project: coolstore
+      provider: s2i
+      version: 1.0
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: coolstore-gw:latest
+    source:
+      contextDir: coolstore-gw
+      git:
+        ref: ${GIT_REF}
+        uri: ${GIT_URI}
+      type: Git
+    strategy:
+      sourceStrategy:
+        env:
+        - name: MAVEN_ARGS
+          value: package -DskipTests -Dfabric8.skip -e -B -Pearly-access-repo
+        - name: MAVEN_ARGS_APPEND
+          value: -Dmaven.repo.remote=http://nexus.ci.svc.cluster.local:8081/repository/maven-public/
+        forcePull: true
+        from:
+          kind: ImageStreamTag
+          name: fis-java-openshift:2.0
+      type: Source
+    triggers:
+    - type: ConfigChange
+    - imageChange: {}
+      type: ImageChange
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: coolstore-gw
+    labels:
+      component: coolstore-gw
+      group: quickstarts
+      project: coolstore
+      provider: s2i
+      version: 1.0
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: coolstore-gw
+    strategy:
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          application: coolstore-gw
+          deploymentconfig: coolstore-gw
+        name: coolstore-gw
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: library/coolstore-gw:latest
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 180
+          name: coolstore-gw
+          ports:
+          - containerPort: 8778
+            name: jolokia
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 10
+          resources: {}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - coolstore-gw
+        from:
+          kind: ImageStreamTag
+          name: coolstore-gw:latest
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The coolstore-gw service's http port.
+    labels:
+      app: coolstore-gw
+    name: coolstore-gw
+  spec:
+    ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      deploymentconfig: coolstore-gw
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+      description: Route for application's coolstore-gw http service.
+    name: coolstore-gw
+  spec:
+    to:
+      kind: Service
+      name: coolstore-gw
+parameters:
+- description: The URL of the repository with your application source code.
+  displayName: Git Repository URL
+  name: GIT_URI
+  required: true
+  value: https://github.com/fabric8-quickstarts/spring-boot-camel.git
+- description: Set this to a branch name, tag or other ref of your repository if you
+    are not using the default branch.
+  displayName: Git Reference
+  name: GIT_REF
+  value: demo-1
+- description: A maven mirror to use
+  displayName: Maven mirror
+  name: MAVEN_MIRROR_URL


### PR DESCRIPTION
Change name of the API Gateway to Coolstore Gateway to not confuse it with a API Mgmt product like 3Scale. Also moved from Camel on top of JBoss EAP to use Camel on FIS 2.0 java image. 