### PR TITLE
Disk quota exceeded -- ideas?

### DIFF
--- a/openshift-templates/services/jenkins.json
+++ b/openshift-templates/services/jenkins.json
@@ -108,7 +108,7 @@
             "metadata": {
                 "name": "jenkins",
                 "labels": {
-                    "template": "jenkins-ephemeral-template"
+                    "template": "jenkins-persistent-template"
                 }
             },
             "spec": {
@@ -152,7 +152,9 @@
                         "volumes": [
                             {
                                 "name": "jenkins-data",
-                                "emptyDir": {}
+                                "persistentVolumeClaim": {
+                                    "claimName": "jenkins-pv"
+                                }
                             }
                         ],
                         "containers": [
@@ -227,7 +229,7 @@
             "metadata": {
                 "name": "jenkins",
                 "labels": {
-                    "template": "jenkins-ephemeral-template"
+                    "template": "jenkins-persistent-template"
                 }
             },
             "spec": {
@@ -245,12 +247,29 @@
             }
         },
         {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "jenkins-pv"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "3Gi"
+          }
+        }
+      }
+},
+        {
             "kind": "Route",
             "apiVersion": "v1",
             "metadata": {
                 "name": "jenkins",
                 "labels": {
-                    "template": "jenkins-ephemeral-template"
+                    "template": "jenkins-persistent-template"
                 }
             },
             "spec": {


### PR DESCRIPTION
I get "Disk quota exceeded" on /var/lib/jenkins* when running on AWS (built with ref architecture installer). It works fine on the CDK.
On the AWS install emptydir limit is set to 512M. I've also installed ephemeral metrics and nexus. Should not be over limit still. 

In this 'fix' which actually does not work, I still get this [1] even after the change, I want to ask what I can do about it. The Disk Quota exceeded error msg is also found below [2]
[1]
Started by an SCM change
Cloning the remote Git repository
Cloning repository https://github.com/jbossdemocentral/coolstore-microservice
 > git init /var/lib/jenkins/jobs/Cart Service/workspace@script # timeout=10
Fetching upstream changes from https://github.com/jbossdemocentral/coolstore-microservice
 > git --version # timeout=10
 > git -c core.askpass=true fetch --tags --progress https://github.com/jbossdemocentral/coolstore-microservice +refs/heads/*:refs/remotes/origin/*
 > git config remote.origin.url https://github.com/jbossdemocentral/coolstore-microservice # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/jbossdemocentral/coolstore-microservice # timeout=10
Fetching upstream changes from https://github.com/jbossdemocentral/coolstore-microservice
 > git -c core.askpass=true fetch --tags --progress https://github.com/jbossdemocentral/coolstore-microservice +refs/heads/*:refs/remotes/origin/*
 > git rev-parse refs/remotes/origin/master^{commit} # timeout=10
 > git rev-parse refs/remotes/origin/origin/master^{commit} # timeout=10
Checking out Revision 1157eb38d4a2cc4a7c459e9e26c4d332cff84e2e (refs/remotes/origin/master)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 1157eb38d4a2cc4a7c459e9e26c4d332cff84e2e
First time build. Skipping changelog.
ERROR: /var/lib/jenkins/jobs/Cart Service/workspace@script/cart-service/Jenkinsfile not found
Finished: FAILURE

[2]
Skipping kubernetes plugin configuration as user provided custom 'config.xml'
Copying Jenkins configuration to /var/lib/jenkins ...
Copying 67 Jenkins plugins to /var/lib/jenkins ...
Creating initial Jenkins 'admin' user ...
Running from: /usr/lib/jenkins/jenkins.war
webroot: EnvVars.masterEnvVars.get("JENKINS_HOME")
Jan 10, 2017 2:46:42 PM winstone.Logger logInternal
INFO: Beginning extraction from war file
Jan 10, 2017 2:46:43 PM org.eclipse.jetty.util.log.JavaUtilLog info
INFO: jetty-winstone-2.9
Jan 10, 2017 2:46:45 PM org.eclipse.jetty.util.log.JavaUtilLog info
INFO: NO JSP Support for , did not find org.apache.jasper.servlet.JspServlet
Jenkins home directory: /var/lib/jenkins found at: EnvVars.masterEnvVars.get("JENKINS_HOME")
Jan 10, 2017 2:46:45 PM org.eclipse.jetty.util.log.JavaUtilLog info
INFO: Started SelectChannelConnector@0.0.0.0:8080
Jan 10, 2017 2:46:45 PM winstone.Logger logInternal
INFO: Winstone Servlet Engine v2.0 running: controlPort=disabled
Jan 10, 2017 2:46:45 PM jenkins.InitReactorRunner$1 onAttained
INFO: Started initialization
Jan 10, 2017 2:46:52 PM jenkins.InitReactorRunner$1 onAttained
INFO: Listed all plugins
Jan 10, 2017 2:46:53 PM jenkins.InitReactorRunner$1 onAttained
INFO: Prepared all plugins
Jan 10, 2017 2:46:57 PM hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1 error
WARNING: Failed to instantiate optional component org.jenkinsci.plugins.workflow.steps.scm.SubversionStep$DescriptorImpl; skipping
Jan 10, 2017 2:46:57 PM hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1 error
WARNING: Failed to instantiate optional component org.jenkinsci.plugins.workflow.steps.scm.GitStep$DescriptorImpl; skipping
Jan 10, 2017 2:46:59 PM io.fabric8.jenkins.openshiftsync.NewBuildWatcher start
INFO: Now handling startup builds!!
Jan 10, 2017 2:46:59 PM io.fabric8.jenkins.openshiftsync.BuildConfigWatcher start
INFO: Now handling startup build configs!!
Jan 10, 2017 2:46:59 PM jenkins.InitReactorRunner$1 onAttained
INFO: Started all plugins
Jan 10, 2017 2:46:59 PM jenkins.InitReactorRunner$1 onAttained
INFO: Augmented all extensions
Jan 10, 2017 2:46:59 PM io.fabric8.jenkins.openshiftsync.NewBuildWatcher$1 run
INFO: Waiting for Jenkins to be started
Jan 10, 2017 2:46:59 PM io.fabric8.jenkins.openshiftsync.NewBuildWatcher$1 run
INFO: loading initial Builds resources
Jan 10, 2017 2:46:59 PM io.fabric8.jenkins.openshiftsync.NewBuildWatcher$1 run
INFO: loaded initial Builds resources
Jan 10, 2017 2:46:59 PM jenkins.InitReactorRunner$1 onAttained
INFO: Loaded all jobs
Jan 10, 2017 2:46:59 PM io.fabric8.jenkins.openshiftsync.BuildConfigWatcher$1 run
INFO: Waiting for Jenkins to be started
Jan 10, 2017 2:46:59 PM io.fabric8.jenkins.openshiftsync.BuildConfigWatcher$1 run
INFO: loading initial BuildConfigs resources
Jan 10, 2017 2:46:59 PM io.fabric8.jenkins.openshiftsync.BuildConfigWatcher$1 run
INFO: loaded initial BuildConfigs resources
Jan 10, 2017 2:46:59 PM hudson.model.AsyncPeriodicWork$1 run
INFO: Started Download metadata
Jan 10, 2017 2:47:00 PM org.jenkinsci.main.modules.sshd.SSHD start
INFO: Started SSHD at port 60911
Jan 10, 2017 2:47:00 PM jenkins.InitReactorRunner$1 onAttained
INFO: Completed initialization
Jan 10, 2017 2:47:00 PM org.springframework.context.support.AbstractApplicationContext prepareRefresh
INFO: Refreshing org.springframework.web.context.support.StaticWebApplicationContext@56677f8e: display name [Root WebApplicationContext]; startup date [Tue Jan 10 14:47:00 EST 2017]; root of context hierarchy
Jan 10, 2017 2:47:00 PM org.springframework.context.support.AbstractApplicationContext obtainFreshBeanFactory
INFO: Bean factory for application context [org.springframework.web.context.support.StaticWebApplicationContext@56677f8e]: org.springframework.beans.factory.support.DefaultListableBeanFactory@5cbed6b4
Jan 10, 2017 2:47:00 PM org.springframework.beans.factory.support.DefaultListableBeanFactory preInstantiateSingletons
INFO: Pre-instantiating singletons in org.springframework.beans.factory.support.DefaultListableBeanFactory@5cbed6b4: defining beans [authenticationManager]; root of factory hierarchy
Jan 10, 2017 2:47:00 PM hudson.triggers.SCMTrigger$Runner run
INFO: SCM changes detected in Cart Service. Triggering  #1
Jan 10, 2017 2:47:00 PM hudson.triggers.SCMTrigger$Runner run
INFO: SCM changes detected in Catalog Service. Triggering  #1
Jan 10, 2017 2:47:00 PM hudson.triggers.SCMTrigger$Runner run
INFO: SCM changes detected in Inventory Service. Triggering  #1
Jan 10, 2017 2:47:00 PM org.springframework.context.support.AbstractApplicationContext prepareRefresh
INFO: Refreshing org.springframework.web.context.support.StaticWebApplicationContext@4b2222d9: display name [Root WebApplicationContext]; startup date [Tue Jan 10 14:47:00 EST 2017]; root of context hierarchy
Jan 10, 2017 2:47:00 PM org.springframework.context.support.AbstractApplicationContext obtainFreshBeanFactory
INFO: Bean factory for application context [org.springframework.web.context.support.StaticWebApplicationContext@4b2222d9]: org.springframework.beans.factory.support.DefaultListableBeanFactory@68420e4a
Jan 10, 2017 2:47:00 PM org.springframework.beans.factory.support.DefaultListableBeanFactory preInstantiateSingletons
INFO: Pre-instantiating singletons in org.springframework.beans.factory.support.DefaultListableBeanFactory@68420e4a: defining beans [filter,legacy]; root of factory hierarchy
Jan 10, 2017 2:47:00 PM jenkins.InitReactorRunner$1 onAttained
INFO: Started initialization
Jan 10, 2017 2:47:00 PM jenkins.InitReactorRunner$1 onAttained
INFO: Listed all plugins
Jan 10, 2017 2:47:00 PM jenkins.InitReactorRunner$1 onAttained
INFO: Prepared all plugins
Jan 10, 2017 2:47:00 PM jenkins.InitReactorRunner$1 onAttained
INFO: Started all plugins
Jan 10, 2017 2:47:00 PM jenkins.InitReactorRunner$1 onAttained
INFO: Augmented all extensions
Jan 10, 2017 2:47:00 PM jenkins.InitReactorRunner$1 onAttained
INFO: Loaded all jobs
Jan 10, 2017 2:47:00 PM jenkins.InitReactorRunner$1 onAttained
INFO: Completed initialization
Jan 10, 2017 2:47:00 PM hudson.WebAppMain$3 run
INFO: Jenkins is fully up and running
Jan 10, 2017 2:47:02 PM hudson.model.UpdateSite updateData
INFO: Obtained the latest update center data file for UpdateSource default
Jan 10, 2017 2:47:03 PM hudson.model.DownloadService$Downloadable load
INFO: Obtained the updated data file for hudson.tasks.Maven.MavenInstaller
Jan 10, 2017 2:47:03 PM hudson.model.DownloadService$Downloadable load
INFO: Obtained the updated data file for hudson.tasks.Ant.AntInstaller
Jan 10, 2017 2:47:04 PM hudson.model.DownloadService$Downloadable load
INFO: Obtained the updated data file for hudson.tools.JDKInstaller
Jan 10, 2017 2:47:04 PM hudson.model.AsyncPeriodicWork$1 run
INFO: Finished Download metadata. 4,582 ms
Jan 10, 2017 2:47:08 PM org.jenkinsci.plugins.workflow.job.WorkflowRun finish
INFO: Cart Service #1 completed: FAILURE
Jan 10, 2017 2:47:08 PM io.fabric8.jenkins.openshiftsync.BuildSyncRunListener onCompleted
INFO: onCompleted job/Cart%20Service/1/
Jan 10, 2017 2:47:08 PM io.fabric8.jenkins.openshiftsync.BuildSyncRunListener onFinalized
INFO: onFinalized job/Cart%20Service/1/
Jan 10, 2017 2:47:10 PM hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1 error
WARNING: Failed to instantiate optional component org.jenkinsci.plugins.workflow.steps.scm.SubversionStep$DescriptorImpl; skipping
Jan 10, 2017 2:47:10 PM hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1 error
WARNING: Failed to instantiate optional component org.jenkinsci.plugins.workflow.steps.scm.GitStep$DescriptorImpl; skipping
Jan 10, 2017 2:47:23 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=11
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Catalog Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.FlowHead.markIfFail(FlowHead.java:142)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext$2.onSuccess(CpsStepContext.java:409)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext$2.onSuccess(CpsStepContext.java:367)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4$1.run(CpsFlowExecution.java:572)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.run(CpsVmExecutorService.java:32)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 24 more

Jan 10, 2017 2:47:23 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=12
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Catalog Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution.addBodyEndFlowNode(CpsBodyExecution.java:337)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution.access$500(CpsBodyExecution.java:54)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution$FailureAdapter.receive(CpsBodyExecution.java:278)
	at com.cloudbees.groovy.cps.impl.ThrowBlock$1.receive(ThrowBlock.java:68)
	at com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21)
	at com.cloudbees.groovy.cps.Next.step(Next.java:58)
	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:154)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable$1.call(SandboxContinuable.java:32)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable$1.call(SandboxContinuable.java:29)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox.runInSandbox(GroovySandbox.java:108)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:29)
	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:164)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:276)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$000(CpsThreadGroup.java:78)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:185)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:183)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:47)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 36 more

Jan 10, 2017 2:47:23 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=12
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Catalog Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution$FailureAdapter.receive(CpsBodyExecution.java:281)
	at com.cloudbees.groovy.cps.impl.ThrowBlock$1.receive(ThrowBlock.java:68)
	at com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21)
	at com.cloudbees.groovy.cps.Next.step(Next.java:58)
	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:154)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable$1.call(SandboxContinuable.java:32)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable$1.call(SandboxContinuable.java:29)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox.runInSandbox(GroovySandbox.java:108)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:29)
	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:164)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:276)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$000(CpsThreadGroup.java:78)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:185)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:183)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:47)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 34 more

Jan 10, 2017 2:47:23 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=13
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Catalog Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.FlowHead.markIfFail(FlowHead.java:142)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext$2.onSuccess(CpsStepContext.java:409)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext$2.onSuccess(CpsStepContext.java:367)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4$1.run(CpsFlowExecution.java:572)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.run(CpsVmExecutorService.java:32)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 24 more

Jan 10, 2017 2:47:23 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=13
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Catalog Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:287)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$000(CpsThreadGroup.java:78)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:185)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:183)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:47)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 23 more

Jan 10, 2017 2:47:23 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=14
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Catalog Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onProgramEnd(CpsFlowExecution.java:827)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:296)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$000(CpsThreadGroup.java:78)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:185)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:183)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:47)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 24 more

Jan 10, 2017 2:47:30 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=11
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Inventory Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.FlowHead.markIfFail(FlowHead.java:142)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext$2.onSuccess(CpsStepContext.java:409)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext$2.onSuccess(CpsStepContext.java:367)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4$1.run(CpsFlowExecution.java:572)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.run(CpsVmExecutorService.java:32)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 24 more

Jan 10, 2017 2:47:30 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=12
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Inventory Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution.addBodyEndFlowNode(CpsBodyExecution.java:337)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution.access$500(CpsBodyExecution.java:54)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution$FailureAdapter.receive(CpsBodyExecution.java:278)
	at com.cloudbees.groovy.cps.impl.ThrowBlock$1.receive(ThrowBlock.java:68)
	at com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21)
	at com.cloudbees.groovy.cps.Next.step(Next.java:58)
	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:154)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable$1.call(SandboxContinuable.java:32)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable$1.call(SandboxContinuable.java:29)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox.runInSandbox(GroovySandbox.java:108)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:29)
	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:164)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:276)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$000(CpsThreadGroup.java:78)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:185)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:183)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:47)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 36 more

Jan 10, 2017 2:47:30 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=12
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Inventory Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution$FailureAdapter.receive(CpsBodyExecution.java:281)
	at com.cloudbees.groovy.cps.impl.ThrowBlock$1.receive(ThrowBlock.java:68)
	at com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21)
	at com.cloudbees.groovy.cps.Next.step(Next.java:58)
	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:154)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable$1.call(SandboxContinuable.java:32)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable$1.call(SandboxContinuable.java:29)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox.runInSandbox(GroovySandbox.java:108)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:29)
	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:164)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:276)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$000(CpsThreadGroup.java:78)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:185)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:183)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:47)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 34 more

Jan 10, 2017 2:47:30 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=13
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Inventory Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.FlowHead.markIfFail(FlowHead.java:142)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext$2.onSuccess(CpsStepContext.java:409)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext$2.onSuccess(CpsStepContext.java:367)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4$1.run(CpsFlowExecution.java:572)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.run(CpsVmExecutorService.java:32)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 24 more

Jan 10, 2017 2:47:30 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=13
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Inventory Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:287)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$000(CpsThreadGroup.java:78)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:185)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:183)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:47)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 23 more

Jan 10, 2017 2:47:30 PM org.jenkinsci.plugins.workflow.graph.FlowNode$1 persist
WARNING: failed to save actions for FlowNode id=14
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Inventory Service/builds/1/workflow
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at org.jenkinsci.plugins.workflow.support.storage.SimpleXStreamFlowNodeStorage.saveActions(SimpleXStreamFlowNodeStorage.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveActions(CpsFlowExecution.java:812)
	at org.jenkinsci.plugins.workflow.graph.FlowNode.save(FlowNode.java:312)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.persist(FlowNode.java:299)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:275)
	at org.jenkinsci.plugins.workflow.graph.FlowNode$1.add(FlowNode.java:266)
	at java.util.AbstractList.add(AbstractList.java:108)
	at hudson.model.Actionable.addAction(Actionable.java:129)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onProgramEnd(CpsFlowExecution.java:827)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:296)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$000(CpsThreadGroup.java:78)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:185)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:183)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:47)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 24 more

Jan 10, 2017 2:47:31 PM org.jenkinsci.plugins.workflow.job.WorkflowRun copyLogs
WARNING: null
java.io.IOException: Failed to create a temporary file in /var/lib/jenkins/jobs/Inventory Service/builds/1
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:68)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:55)
	at hudson.XmlFile.write(XmlFile.java:175)
	at hudson.model.Run.save(Run.java:1896)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.copyLogs(WorkflowRun.java:398)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.access$600(WorkflowRun.java:111)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$3.run(WorkflowRun.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Disk quota exceeded
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at hudson.util.AtomicFileWriter.<init>(AtomicFileWriter.java:66)
	... 13 more