### PR TITLE
Exclude old JSR-311 API to avoid NoSuchMethodError on catalog-service

### DIFF
--- a/catalog-service/pom.xml
+++ b/catalog-service/pom.xml
@@ -50,7 +50,13 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
-      <version>1.5.8</version>
+      <version>1.5.12</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>jsr311-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.webjars</groupId>


### PR DESCRIPTION
Fixes #20 