### PR TITLE
Pin to specific patch level of PatternFly to insulate from upstream e…

### DIFF
--- a/coolstore-ui/bower.json
+++ b/coolstore-ui/bower.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "private": true,
   "devDependencies": {
-    "patternfly": "^3.3.2",
-    "angular-patternfly": "^3.3.2",
+    "patternfly": "~3.18.0",
+    "angular-patternfly": "~3.18.0",
     "isotope": "^2.2.2",
     "imagesloaded": "^4.1.0",
     "angular-route": "1.5.x",


### PR DESCRIPTION
…rrors

This is the last known version (3.18.x). 3.19 introduced a [new error](https://github.com/patternfly/angular-patternfly/issues/401) so to avoid this and future errors, stop pulling in 3.x.x and start pulling in 3.18.x so we can better control the upstream dependency.