### PR TITLE
Configurable Shopping Cart Service implementation

### DIFF
--- a/cart-service/src/main/java/com/redhat/coolstore/CartServiceConfiguration.java
+++ b/cart-service/src/main/java/com/redhat/coolstore/CartServiceConfiguration.java
@@ -1,0 +1,26 @@
+package com.redhat.coolstore;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.redhat.coolstore.service.ShoppingCartService;
+import com.redhat.coolstore.service.ShoppingCartServiceImpl;
+import com.redhat.coolstore.service.ShoppingCartServiceImplDecisionServer;
+
+@Configuration
+public class CartServiceConfiguration {
+    
+    @Value("${pricing.service.impl}")
+    private String pricingService;
+    
+    @Bean
+    public ShoppingCartService getShoppingCartService() {
+        if ("drools".equals(pricingService)) {
+          return new ShoppingCartServiceImplDecisionServer();  
+        } else {
+          return new ShoppingCartServiceImpl();
+        }
+    }
+
+}

--- a/cart-service/src/main/java/com/redhat/coolstore/service/ShoppingCartServiceImpl.java
+++ b/cart-service/src/main/java/com/redhat/coolstore/service/ShoppingCartServiceImpl.java
@@ -7,13 +7,11 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import com.redhat.coolstore.model.Product;
 import com.redhat.coolstore.model.ShoppingCart;
 import com.redhat.coolstore.model.ShoppingCartItem;
 
-@Component
 public class ShoppingCartServiceImpl implements ShoppingCartService {
 	
 	@Autowired

--- a/cart-service/src/main/java/com/redhat/coolstore/service/ShoppingCartServiceImplDecisionServer.java
+++ b/cart-service/src/main/java/com/redhat/coolstore/service/ShoppingCartServiceImplDecisionServer.java
@@ -24,18 +24,16 @@ import org.kie.server.client.RuleServicesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
-import com.redhat.coolstore.model.kie.PromoEvent;
 import com.redhat.coolstore.model.Product;
 import com.redhat.coolstore.model.Promotion;
 import com.redhat.coolstore.model.ShoppingCart;
 import com.redhat.coolstore.model.ShoppingCartItem;
+import com.redhat.coolstore.model.kie.PromoEvent;
 
 import feign.Feign;
 import feign.jackson.JacksonDecoder;
 
-@Component
 public class ShoppingCartServiceImplDecisionServer implements ShoppingCartService {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(ShoppingCartServiceImplDecisionServer.class);

--- a/cart-service/src/main/resources/application.properties
+++ b/cart-service/src/main/resources/application.properties
@@ -2,3 +2,4 @@ spring.application.name=cart-service
 spring.jersey.application-path=/api
 
 catalog.service.url=http://catalog-service:8080
+pricing.service.impl=drools


### PR DESCRIPTION
The Spring Boot cart service has 2 implementation classes for ShoppingCartService:
* com.redhat.coolstore.service.ShoppingCartServiceImplDecisionServer
* com.redhat.coolstore.service.ShoppingCartServiceImpl

When running the cart app, SB generates a NoUniqueBeanDefinitionException exception:

```
org.springframework.beans.factory.NoUniqueBeanDefinitionException: No qualifying bean of type
'com.redhat.coolstore.service.ShoppingCartService' available: 
expected single matching bean but found 2: 
shoppingCartServiceImplDecisionServer,shoppingCartServiceImpl
```

The PR makes the implementation of the ShoppingCartService configurable. If the value of the 'pricing.service.impl' property is set to 'drools', ShoppingCartServiceImplDecisionServer is used, else ShoppingCartServiceImpl is used.