### PR TITLE
#45 Update version of fabric8 spring camel starter maven dependency to use latest publicly available

### DIFF
--- a/coolstore-gw/pom.xml
+++ b/coolstore-gw/pom.xml
@@ -12,8 +12,8 @@
 
 	<properties>
 	   <spring-boot.version>1.4.1.RELEASE</spring-boot.version>
-    	<fabric8.version>2.2.170.redhat-000010</fabric8.version>
-    	<fabric8.maven.plugin.version>3.1.80.redhat-000010</fabric8.maven.plugin.version>
+    	<fabric8.version>2.2.192</fabric8.version>
+    	<fabric8.maven.plugin.version>3.4.0</fabric8.maven.plugin.version>
     	<maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
     	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     	<maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
@@ -158,19 +158,4 @@
       </plugin>
     </plugins>
 	</build>
-
-	<repositories>
-  <repository>
-    <id>jboss.fuse</id>
-    <name>JBoss Fuse Public</name>
-    <url>https://repo.fusesource.com/nexus/content/groups/public/</url>
-  </repository>
-  </repositories>
-  <pluginRepositories>
-  <pluginRepository>
-    <id>jboss.fuse</id>
-    <name>JBoss Fuse Public</name>
-    <url>https://repo.fusesource.com/nexus/content/groups/public/</url>
-  </pluginRepository>
-  </pluginRepositories>
 </project>


### PR DESCRIPTION
Using publicly available maven dependencies seems more stable than constantly-changing versions from the fuse repo