### PR TITLE
updated jquery from 3.2.1 to 3.3.1

### DIFF
--- a/coolstore-ui/bower.json
+++ b/coolstore-ui/bower.json
@@ -16,6 +16,6 @@
     },
     "resolutions": {
         "angular": "1.5.10",
-        "jquery": "3.2.1"
+        "jquery": "3.3.1"
     }
 }


### PR DESCRIPTION
web-ui build with old version of jquery fails.  Updated jquery from 3.2.1 to 3.3.1 allows build to complete