### PR TITLE
Modify troubleshooting URLs to point to correct tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Troubleshooting
 
   ```
   oc login -u system:admin
-  oc create -n openshift -f https://raw.githubusercontent.com/openshift/openshift-ansible/master/roles/openshift_examples/files/examples/v3.9/xpaas-streams/fis-image-streams.json
-  oc create -n openshift -f https://raw.githubusercontent.com/openshift/openshift-ansible/master/roles/openshift_examples/files/examples/v3.9/xpaas-streams/jboss-image-streams.json
+  oc create -n openshift -f https://raw.githubusercontent.com/openshift/openshift-ansible/release-3.8/roles/openshift_examples/files/examples/v3.9/xpaas-streams/fis-image-streams.json
+  oc create -n openshift -f https://raw.githubusercontent.com/openshift/openshift-ansible/release-3.8/roles/openshift_examples/files/examples/v3.9/xpaas-streams/jboss-image-streams.json
   ```
 
 * If you attempt to deploy any of the services, and nothing happens, it may just be taking a while to download the Docker builder images. Visit the OpenShift web console and navigate to


### PR DESCRIPTION
The URLs pointed to the master branch and the target JSON files had been refactored away in master.

The reason I changed this to the `release-3.8` tag is for two reasons. The first is that the JBoss image streams have been split into multiple files, and the second is that the latest commit for the tag is to add 3.9 support:
* [tag `release-3.8`](https://github.com/openshift/openshift-ansible/tree/release-3.8/roles/openshift_examples/files/examples/v3.9/xpaas-streams)
* [tag `release-3.9`](https://github.com/openshift/openshift-ansible/tree/release-3.9/roles/openshift_examples/files/examples/v3.9/xpaas-streams)
* [404 in `master`](https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_examples/files/examples/v3.9/xpaas-streams)