### PR TITLE
Changed GIT_REF to stable-ocp-3.11

### DIFF
--- a/openshift/coolstore-template.yaml
+++ b/openshift/coolstore-template.yaml
@@ -1792,7 +1792,7 @@ parameters:
 - displayName: Git branch/tag reference
   name: GIT_REF
   required: true
-  value: stable-ocp-3.10
+  value: stable-ocp-3.11
 - description: Maven mirror url. If nexus is deployed locally, use nexus url (e.g. http://nexus.ci:8081/content/groups/public/)
   displayName: Maven mirror url
   name: MAVEN_MIRROR_URL


### PR DESCRIPTION
If you are processing the template from branch stable-ocp-3.11 the template refers to stable-ocp-3.10. In my opinion this is an issue which should be fixed. 